### PR TITLE
Fix Deprecated Function

### DIFF
--- a/lib/src/blocs/movie_detail_bloc_provider.dart
+++ b/lib/src/blocs/movie_detail_bloc_provider.dart
@@ -15,8 +15,6 @@ class MovieDetailBlocProvider extends InheritedWidget {
   }
 
   static MovieDetailBloc of(BuildContext context) {
-    return (context.inheritFromWidgetOfExactType(MovieDetailBlocProvider)
-            as MovieDetailBlocProvider)
-        .bloc;
+    return context.dependOnInheritedWidgetOfExactType<MovieDetailBlocProvider>().bloc;
   }
 }


### PR DESCRIPTION
Greetings. Thank you for the tutorial. The inheritFromWidgetOfExactType method is deprecated so I think this small change may help folks in the future. 

This is also actually my first PR haha. I'm sorry if this is too minor. I'm thinking also of making PR on migrating the codes into AndroidX. Is that okay? 

Thank you.